### PR TITLE
ci(default): upgrade to setup-nix v2

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[[analyzers]]
+name = "shell"
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   precommit:
-    name: Pre-commit Check
+    name: Pre-Commit
     runs-on:
       - nscloud-ubuntu-22.04-amd64-4x8-with-cache
       - nscloud-cache-size-50gb
@@ -13,7 +13,7 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v1
+      - uses: AtomiCloud/actions.setup-nix@v2
 
       # pre commit
       - name: Run pre-commit
@@ -33,7 +33,7 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v1
+      - uses: AtomiCloud/actions.setup-nix@v2
 
       - name: Nix Build
         run: >-
@@ -86,7 +86,10 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v1
+      - uses: AtomiCloud/actions.setup-nix@v2
+        with:
+          auth-bot-app-id: ${{ vars.AUTH_BOT_APP_ID }}
+          auth-bot-secret-key: ${{ secrets.AUTH_BOT_SECRET_KEY }}
       - uses: AtomiCloud/actions.cache-npm@v1
 
       # action


### PR DESCRIPTION
- changed action from setup-nix@v1 to setup-nix@v2 in pre-commit job
- changed action from setup-nix@v1 to setup-nix@v2 in build job
- added auth-bot-app-id and auth-bot-secret-key to setup-nix@v2 in action job

upgrading to setup-nix v2 provides improved features and fixes, ensuring better CI performance and security with the addition of authentication parameters.