### PR TITLE
update(mirrord): to 3.171.0

### DIFF
--- a/binWrapper/mirrord.nix
+++ b/binWrapper/mirrord.nix
@@ -15,14 +15,14 @@ let
   archive_fmt = "tar.gz";
 
   sha256 = {
-    x86_64-linux = "sha256-GP7n7oTuecRwstUOguaOhHx9HiwNoFO0BSWX2/AB6LI=";
-    aarch64-linux = "sha256-WExPypRI9eDpUXoCNkAeO5rsDHULZbpBWLYQxRdvN7I=";
+    x86_64-linux = "sha256-Xzy8Qvsw/nVTa6PRRdsBbOZHfPGKzRimbOVDa6qqVXc=";
+    aarch64-linux = "sha256-7h7eRqypiqv0Ri9Bc61+AkYVm12GPwsPQKYYtMoyLho=";
 
-    x86_64-darwin = "sha256-Llui3SXZl15YBtjrr1PbWtyDRBGWdKvMQ8zTqgwgc8s=";
-    aarch64-darwin = "sha256-Llui3SXZl15YBtjrr1PbWtyDRBGWdKvMQ8zTqgwgc8s=";
+    x86_64-darwin = "sha256-rvlU8erkgb/Sdythejl02w76gaZXB8CmfiW0FMadcA4=";
+    aarch64-darwin = "sha256-rvlU8erkgb/Sdythejl02w76gaZXB8CmfiW0FMadcA4=";
   }.${system} or throwSystem;
 in
-let version = "3.128.0"; in
+let version = "3.171.0"; in
 let
   binary = fetchurl {
     url = "https://github.com/metalbear-co/mirrord/releases/download/${version}/mirrord_${plat}";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mirrord to version 3.171.0 with support for x86_64-linux, aarch64-linux, x86_64-darwin, and aarch64-darwin platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->