### PR TITLE
[CU-86ewgp2bh] incorrect darwin-arm slug

### DIFF
--- a/binWrapper/mirrord.nix
+++ b/binWrapper/mirrord.nix
@@ -9,7 +9,7 @@ let
     aarch64-linux = "linux_aarch64";
 
     x86_64-darwin = "mac_universal";
-    aarch64-darwin = "linux_x86_64";
+    aarch64-darwin = "mac_universal";
   }.${system} or throwSystem;
 
   archive_fmt = "tar.gz";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed binary download for Apple Silicon Mac systems to use the correct compatible binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->