### PR TITLE
new(ccc): chat with claude code on telegram [CU-86ewrbfra]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
           .#cliproxyapi
           .#deadcode
           .#coderabbit
+          .#ccc
           -c bash -c '
           sg --version &&
           upstash --version &&
@@ -83,6 +84,7 @@ jobs:
           dn-inspect --version &&
           deadcode --version &&
           coderabbit --version &&
+          ccc --version &&
           helmlint --version &&
           attic --version &&
           cli-proxy-api --help &&

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 .direnv
 .DS_Store
 .kagent
+.garden

--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,7 @@ let
   # Go
   golang = {
     nix-share = import ./golang/nix-share/default.nix { inherit nixpkgs; };
+    ccc = import ./golang/ccc/default.nix { inherit nixpkgs; };
   };
 
   # dotnet

--- a/golang/ccc/default.nix
+++ b/golang/ccc/default.nix
@@ -18,5 +18,5 @@ buildGoModule rec {
 
   doCheck = false;
 
-  ldflags = [ "-w" "-s" "-a" ];
+  ldflags = [ "-w" "-s" ];
 }

--- a/golang/ccc/default.nix
+++ b/golang/ccc/default.nix
@@ -1,0 +1,22 @@
+{ nixpkgs }:
+with nixpkgs;
+buildGoModule rec {
+  pname = "ccc";
+  version = "v1.6.2";
+
+  meta = {
+    owner = "kidandcat";
+    repo = "ccc";
+  };
+
+  src = fetchurl {
+    url = "https://github.com/${meta.owner}/${meta.repo}/archive/refs/tags/${version}.tar.gz";
+    sha256 = "sha256-dol/S1xfMuLSb3hjIQIk85PaN6lgWuYVMUl3zfJUpIg=";
+  };
+
+  vendorHash = "sha256-7sDFP9a7SQr148jt7bGCAx6m5R3HHPT3+RxbpUYjrPY=";
+
+  doCheck = false;
+
+  ldflags = [ "-w" "-s" "-a" ];
+}

--- a/spec/CU-86ewrbfra/v1/task-spec.md
+++ b/spec/CU-86ewrbfra/v1/task-spec.md
@@ -1,0 +1,132 @@
+# Task Specification: Add ccc to Nix registry (CU-86ewrbfra)
+
+## Source
+
+- Ticket: CU-86ewrbfra
+- System: ClickUp
+- URL: https://app.clickup.com/t/86ewrbfra
+
+## Objective
+
+Add `ccc` (Claude Code Companion) as a Go package to the nix-registry using `buildGoModule`. This is a CLI tool that allows remote control of Claude Code sessions via Telegram.
+
+## Acceptance Criteria
+
+- [ ] Package builds successfully with `nix build .#ccc`
+- [ ] Binary runs correctly with `nix shell .#ccc -c ccc --help`
+- [ ] Package added to CI verification workflow
+- [ ] Commit follows convention: `new(ccc): chat with claude code on telegram`
+
+## Definition of Done
+
+- [ ] All acceptance criteria met
+- [ ] No lint errors (nix fmt passes)
+- [ ] Ticket ID included in commit message
+- [ ] PR created and ready for review
+
+## Out of Scope
+
+- Adding `ccc` to `nix/registry.nix` (dev shell registry) - not needed
+- Building for platforms without pre-built binaries (darwin-x64, linux-arm64)
+- Creating multiple version variants
+
+## Technical Constraints
+
+- Must use `buildGoModule` pattern (not binWrapper)
+- Must use `vendorHash` with SRI format
+- Package location: `golang/ccc/default.nix`
+- Version: v1.6.2
+
+## Context
+
+**About ccc:**
+
+- Repository: https://github.com/kidandcat/ccc
+- License: MIT
+- Language: Go
+- Description: Chat with Claude Code on Telegram - allows remote control of Claude Code sessions
+
+**Latest Release (v1.6.2):**
+
+- Published: 2026-02-18
+- Bug Fix: extractLastTurn now handles flat JSONL format from Claude Code v2.1.45+
+
+## Technical Decisions
+
+| Decision            | Choice        | Reasoning                                                     |
+| ------------------- | ------------- | ------------------------------------------------------------- |
+| Package type        | buildGoModule | User requested building from source for full platform support |
+| Package location    | `golang/ccc/` | Following existing pattern for Go packages                    |
+| Add to registry.nix | No            | Not needed for dev shells, just a buildable package           |
+| Version             | v1.6.2        | Latest release at time of implementation                      |
+
+## Implementation Steps (from Golang Package Guide)
+
+1. **Create directory structure**
+
+   ```bash
+   mkdir -p golang/ccc
+   ```
+
+2. **Create package definition** (`golang/ccc/default.nix`)
+   - Use `buildGoModule` pattern
+   - Set placeholder hashes initially
+   - Configure `doCheck = false` (CLI tool, may require network)
+
+3. **Import in default.nix**
+   Add to the `golang` section in `/default.nix`
+
+4. **Generate correct hashes**
+
+   ```bash
+   pls gen:go:sha -- ccc ccc/default
+   pls gen:go:vendor:sha -- ccc ccc/default
+   ```
+
+5. **Test the build**
+
+   ```bash
+   nix build .#ccc
+   nix shell .#ccc -c ccc --help
+   ```
+
+6. **Add to CI verification**
+   - Add to `.github/workflows/ci.yaml` nix shell command
+   - Add version/help check command
+
+## Package Template
+
+```nix
+{ nixpkgs }:
+with nixpkgs;
+buildGoModule rec {
+  pname = "ccc";
+  version = "v1.6.2";
+
+  meta = {
+    owner = "kidandcat";
+    repo = "ccc";
+  };
+
+  src = fetchurl {
+    url = "https://github.com/${meta.owner}/${meta.repo}/archive/refs/tags/${version}.tar.gz";
+    sha256 = "<to-be-generated>";
+  };
+
+  vendorHash = "<to-be-generated>";
+
+  doCheck = false;
+
+  ldflags = [ "-w" "-s" "-a" ];
+}
+```
+
+## Edge Cases
+
+- **Hash mismatch**: Use `pls gen:go:sha` and `pls gen:go:vendor:sha` to regenerate
+- **Network access in tests**: Already setting `doCheck = false`
+
+## Error Handling
+
+- Build failure: Check hashes are correct using pls commands
+- Missing dependencies: vendorHash should handle Go module dependencies

--- a/spec/CU-86ewrbfra/v1/task-spec.md
+++ b/spec/CU-86ewrbfra/v1/task-spec.md
@@ -12,17 +12,17 @@ Add `ccc` (Claude Code Companion) as a Go package to the nix-registry using `bui
 
 ## Acceptance Criteria
 
-- [ ] Package builds successfully with `nix build .#ccc`
-- [ ] Binary runs correctly with `nix shell .#ccc -c ccc --help`
-- [ ] Package added to CI verification workflow
-- [ ] Commit follows convention: `new(ccc): chat with claude code on telegram`
+- [x] Package builds successfully with `nix build .#ccc`
+- [x] Binary runs correctly with `nix shell .#ccc -c ccc --help`
+- [x] Package added to CI verification workflow
+- [x] Commit follows convention: `new(ccc): chat with claude code on telegram`
 
 ## Definition of Done
 
-- [ ] All acceptance criteria met
-- [ ] No lint errors (nix fmt passes)
-- [ ] Ticket ID included in commit message
-- [ ] PR created and ready for review
+- [x] All acceptance criteria met
+- [x] No lint errors (nix fmt passes)
+- [x] Ticket ID included in commit message
+- [x] PR created and ready for review
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- Add `ccc` (Chat with Claude Code) Go package v1.6.2 to the nix registry
- Integrate `ccc` into CI workflow for verification

## Changes

- **golang/ccc/default.nix**: New package definition for ccc CLI tool
- **default.nix**: Import the new ccc package
- **.github/workflows/ci.yaml**: Add `.#ccc` to nix shell and `ccc --version` to verification

## Test plan

- [x] `nix build .#ccc` - Build succeeds
- [x] `nix shell .#ccc -c ccc --version` - Returns `ccc version 1.6.2`
- [x] `nix shell .#ccc -c ccc --help` - Displays CLI documentation
- [x] `nix fmt` - All files formatted
- [x] CI workflow includes ccc verification

## Reference

- Ticket: [CU-86ewrbfra](https://app.clickup.com/t/86ewrbfra)
- Upstream: https://github.com/kidandcat/ccc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new Go package to the registry and integrated it into the build matrix and CI version checks.
  * Updated ignore list to include an additional development artifact.

* **Documentation**
  * Added a detailed specification and implementation guide for integrating the new package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->