### PR TITLE
remove(darwin-intel): drop x86_64-darwin (Intel macOS) support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,18 @@ jobs:
     steps:
       # Setup
       - uses: AtomiCloud/actions.setup-nix@v3
+        with:
+          # Pull AtomiCloud-built packages (cyanprint, etc.) from attic instead
+          # of compiling them. The per-arch caches start cold on first run, and
+          # building cyanprint's rust closure from source OOMs the 4x8 runners.
+          attic: 'true'
+          attic-token: ${{ secrets.ATTIC_TOKEN }}
 
+      # --max-jobs/--cores cap peak memory for any residual source builds
+      # (e.g. worktrunk, attic) that aren't in attic, so they don't OOM.
       - name: Nix Build
         run: >-
-          nix shell nixpkgs#bash
+          nix shell --max-jobs 2 --cores 2 nixpkgs#bash
           .#sg
           .#upstash
           .#action_docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: AtomiCloud/actions.setup-nix@v3
       # pre commit
       - name: Run pre-commit
         run: nix develop .#ci -c ./scripts/ci/pre-commit.sh
@@ -22,17 +22,34 @@ jobs:
     name: Nix Build
     strategy:
       matrix:
-        os:
-          - nscloud-ubuntu-22.04-amd64-4x8-with-cache
-          - nscloud-ubuntu-22.04-arm64-4x8-with-cache
-    runs-on:
-      - ${{ matrix.os }}
-      - nscloud-cache-size-50gb
-      - nscloud-cache-tag-nix-registry-nix-build-store-cache
-      - nscloud-git-mirror-1gb
+        # Each architecture gets its OWN cache tag. amd64 and arm64 previously
+        # shared one tag (nix-registry-nix-build-store-cache); since both jobs
+        # mount and persist the same Namespace volume concurrently, the slower
+        # job's store would overwrite the faster one's, so the two arches kept
+        # clobbering each other's cache (one warm, the other cold every run).
+        platform:
+          - name: Linux x86_64
+            os:
+              - nscloud-ubuntu-22.04-amd64-4x8-with-cache
+              - nscloud-cache-size-50gb
+              - nscloud-cache-tag-nix-registry-nix-build-store-cache-amd64
+              - nscloud-git-mirror-1gb
+          - name: Linux aarch64
+            os:
+              - nscloud-ubuntu-22.04-arm64-4x8-with-cache
+              - nscloud-cache-size-50gb
+              - nscloud-cache-tag-nix-registry-nix-build-store-cache-arm64
+              - nscloud-git-mirror-1gb
+          - name: MacOS aarch64
+            os:
+              - nscloud-macos-sequoia-arm64-6x14-with-cache
+              - nscloud-cache-size-50gb
+              - nscloud-cache-tag-nix-registry-nix-build-store-cache-macos-arm64
+              - nscloud-git-mirror-1gb
+    runs-on: ${{ matrix.platform.os }}
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: AtomiCloud/actions.setup-nix@v3
 
       - name: Nix Build
         run: >-
@@ -111,7 +128,7 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: AtomiCloud/actions.setup-nix@v3
         with:
           auth-bot-app-id: ${{ vars.AUTH_BOT_APP_ID }}
           auth-bot-secret-key: ${{ secrets.AUTH_BOT_SECRET_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,22 +21,29 @@ jobs:
   build:
     name: Nix Build
     strategy:
+      # Per-arch caches are independent, so one arch failing/cold-building
+      # should not cancel the others.
+      fail-fast: false
       matrix:
         # Each architecture gets its OWN cache tag. amd64 and arm64 previously
         # shared one tag (nix-registry-nix-build-store-cache); since both jobs
         # mount and persist the same Namespace volume concurrently, the slower
         # job's store would overwrite the faster one's, so the two arches kept
         # clobbering each other's cache (one warm, the other cold every run).
+        #
+        # Linux runners are 8x16 (16GB): on a cold cache the heavy rust
+        # workspaces (cyanprint, worktrunk, attic) are built from source, and a
+        # single one needs more than the old 4x8 (8GB) runner had.
         platform:
           - name: Linux x86_64
             os:
-              - nscloud-ubuntu-22.04-amd64-4x8-with-cache
+              - nscloud-ubuntu-22.04-amd64-8x16-with-cache
               - nscloud-cache-size-50gb
               - nscloud-cache-tag-nix-registry-nix-build-store-cache-amd64
               - nscloud-git-mirror-1gb
           - name: Linux aarch64
             os:
-              - nscloud-ubuntu-22.04-arm64-4x8-with-cache
+              - nscloud-ubuntu-22.04-arm64-8x16-with-cache
               - nscloud-cache-size-50gb
               - nscloud-cache-tag-nix-registry-nix-build-store-cache-arm64
               - nscloud-git-mirror-1gb
@@ -54,8 +61,8 @@ jobs:
       # The per-arch caches start cold on first run, so the heavy rust
       # workspaces (cyanprint, worktrunk, attic) are compiled from source.
       # --max-jobs 1 serialises derivations so only one of those links at a
-      # time — building two concurrently OOMs the 4x8 (8GB) runners. Once the
-      # Namespace /nix cache is warm this run is ~1 min regardless.
+      # time, keeping peak memory within the 16GB runner. Once the Namespace
+      # /nix cache is warm this run is ~1 min regardless.
       - name: Nix Build
         run: >-
           nix shell --max-jobs 1 --cores 2 nixpkgs#bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,15 +50,10 @@ jobs:
     steps:
       # Setup
       - uses: AtomiCloud/actions.setup-nix@v3
-        with:
-          # Pull AtomiCloud-built packages (cyanprint, etc.) from attic instead
-          # of compiling them. The per-arch caches start cold on first run, and
-          # building cyanprint's rust closure from source OOMs the 4x8 runners.
-          attic: 'true'
-          attic-token: ${{ secrets.ATTIC_TOKEN }}
 
-      # --max-jobs/--cores cap peak memory for any residual source builds
-      # (e.g. worktrunk, attic) that aren't in attic, so they don't OOM.
+      # The per-arch caches start cold on first run, so the rust closure
+      # (cyanprint, etc.) is compiled from source. --max-jobs/--cores cap peak
+      # memory so those builds don't OOM the 4x8 runners.
       - name: Nix Build
         run: >-
           nix shell --max-jobs 2 --cores 2 nixpkgs#bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,12 +51,14 @@ jobs:
       # Setup
       - uses: AtomiCloud/actions.setup-nix@v3
 
-      # The per-arch caches start cold on first run, so the rust closure
-      # (cyanprint, etc.) is compiled from source. --max-jobs/--cores cap peak
-      # memory so those builds don't OOM the 4x8 runners.
+      # The per-arch caches start cold on first run, so the heavy rust
+      # workspaces (cyanprint, worktrunk, attic) are compiled from source.
+      # --max-jobs 1 serialises derivations so only one of those links at a
+      # time — building two concurrently OOMs the 4x8 (8GB) runners. Once the
+      # Namespace /nix cache is warm this run is ~1 min regardless.
       - name: Nix Build
         run: >-
-          nix shell --max-jobs 2 --cores 2 nixpkgs#bash
+          nix shell --max-jobs 1 --cores 2 nixpkgs#bash
           .#sg
           .#upstash
           .#action_docs

--- a/.github/workflows/⚡reusable-cachebuild.yaml
+++ b/.github/workflows/⚡reusable-cachebuild.yaml
@@ -9,9 +9,6 @@ on:
       darwin-aarch64:
         default: true
         type: boolean
-      darwin-x86_64:
-        default: true
-        type: boolean
       linux-x86_64:
         default: true
         type: boolean
@@ -39,11 +36,6 @@ jobs:
               - nscloud-ubuntu-22.04-arm64-4x8-with-cache
               - nscloud-cache-size-50gb
               - nscloud-cache-tag-home-manager-nix-store-cache
-          - name: MacOS x86_64
-            namespacelabs: false
-            enabled: ${{ inputs.darwin-x86_64 }}
-            os:
-              - macos-13
           - name: MacOS aarch64
             namespacelabs: false
             enabled: ${{ inputs.darwin-aarch64 }}
@@ -52,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: AtomiCloud/actions.setup-nix@v3
         if: ${{ matrix.platform.enabled }}
         with:
           namespacelabs: ${{ matrix.platform.namespacelabs }}

--- a/.github/workflows/⚡reusable-cacheshell.yaml
+++ b/.github/workflows/⚡reusable-cacheshell.yaml
@@ -9,9 +9,6 @@ on:
       darwin-aarch64:
         default: true
         type: boolean
-      darwin-x86_64:
-        default: true
-        type: boolean
       linux-x86_64:
         default: true
         type: boolean
@@ -39,11 +36,6 @@ jobs:
               - nscloud-ubuntu-22.04-arm64-4x8-with-cache
               - nscloud-cache-size-50gb
               - nscloud-cache-tag-home-manager-nix-store-cache
-          - name: MacOS x86_64
-            namespacelabs: false
-            enabled: ${{ inputs.darwin-x86_64 }}
-            os:
-              - macos-13
           - name: MacOS aarch64
             namespacelabs: false
             enabled: ${{ inputs.darwin-aarch64 }}
@@ -52,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: AtomiCloud/actions.setup-nix@v3
         if: ${{ matrix.platform.enabled }}
         with:
           namespacelabs: ${{ matrix.platform.namespacelabs }}

--- a/binWrapper/cliproxyapi.nix
+++ b/binWrapper/cliproxyapi.nix
@@ -8,14 +8,12 @@ let
     x86_64-linux = "linux_amd64";
     aarch64-linux = "linux_arm64";
     aarch64-darwin = "darwin_arm64";
-    x86_64-darwin = "darwin_amd64";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-linux = "b5a2af814e270854f35bb44b2b75d1bdba50c867f0bee732f82d7825406a3fce";
     aarch64-linux = "2ffd1b98f339e7188fecc23fb3e8825ef247c39ade0b60ca680ecec6a39574ed";
     aarch64-darwin = "610e416f8db1a53b3812273ac295110b9d394380a1293ff2cf0e48c7c902a124";
-    x86_64-darwin = "a44e23b073bbd66ad5ac43f3632554d26c2babe18065c527a4aeabaf66ba5551";
   }.${system} or throwSystem;
 in
 let version = "v6.7.16"; in
@@ -61,6 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://help.router-for.me/";
     downloadPage = "https://github.com/router-for-me/CLIProxyAPI/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
 })

--- a/binWrapper/codecov.nix
+++ b/binWrapper/codecov.nix
@@ -34,6 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
   # We don't need to build anything
   buildPhase = "true";
 
+  # codecov is a PyInstaller binary: the Python runtime and app are appended to
+  # the executable as a ~23MB archive. macOS `strip` (run in fixupPhase) discards
+  # that appended archive, leaving a ~170KB stub that fails at runtime with
+  # "Could not load PyInstaller's embedded PKG archive". Keep the binary intact.
+  dontStrip = true;
+
   installPhase = ''
     mkdir -p $out/bin
     cp $src $out/bin/codecov

--- a/binWrapper/codecov.nix
+++ b/binWrapper/codecov.nix
@@ -8,7 +8,6 @@ let
     x86_64-linux = "linux";
     aarch64-linux = "linux-arm64";
     aarch64-darwin = "macos";
-    x86_64-darwin = "macos";
   }.${system} or throwSystem;
 
 
@@ -16,7 +15,6 @@ let
     x86_64-linux = "0f7aadde579ebde1443ad2f977beada703f562997fdda603f213faf2a8559868";
     aarch64-linux = "a26e29f6c9480a1226a850c57f80bc79f0ea0c9e59e6440530577bd3d11fef2f";
     aarch64-darwin = "1627507cf5b4d2f7c86247428cc2b6d02fbfa6aa380847cd047a33949d3bdbe1";
-    x86_64-darwin = "1627507cf5b4d2f7c86247428cc2b6d02fbfa6aa380847cd047a33949d3bdbe1";
   }.${system} or throwSystem;
 in
 let version = "v10.4.0"; in
@@ -55,6 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://codecov.io/";
     downloadPage = "https://github.com/codecov/codecov-cli/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
 })

--- a/binWrapper/coderabbit.nix
+++ b/binWrapper/coderabbit.nix
@@ -7,14 +7,12 @@ let
   plat = {
     x86_64-linux = "linux-x64";
     aarch64-linux = "linux-arm64";
-    x86_64-darwin = "darwin-x64";
     aarch64-darwin = "darwin-arm64";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-linux = "sha256-X87wVqXBjaZaPz/ER/ExyV5EqZqE7IudlRF2cOFL04A=";
     aarch64-linux = "sha256-XDmdcQHoEBqq1Z6OGrRa96/oXRNpCnPr4P0pa40wPEo=";
-    x86_64-darwin = "sha256-daJTcCypYbZGqQa2Z3BshaeoxrdtMxTJSUXgDbILu/4=";
     aarch64-darwin = "sha256-s5A/FDmEQ28kGyQniV5entMAdjeLIR+/oC/DiJocw6k=";
   }.${system} or throwSystem;
 in
@@ -54,6 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://coderabbit.ai/";
     downloadPage = "https://github.com/coderabbitai/coderabbit-cli/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
 })

--- a/binWrapper/gardenio.nix
+++ b/binWrapper/gardenio.nix
@@ -8,7 +8,6 @@ let
     x86_64-linux = "linux-amd64";
     aarch64-linux = "linux-arm64";
 
-    x86_64-darwin = "macos-amd64";
     aarch64-darwin = "macos-arm64";
   }.${system} or throwSystem;
 
@@ -18,7 +17,6 @@ let
     x86_64-linux = "sha256-g+FISR4Ay1yoMcrrQBo9G8XLjWa5chUK+WoSmreqxQU=";
     aarch64-linux = "sha256-ehlnl2JezQGxPHkICaj/0t58C2M2v/mQuNhbmNNC284=";
 
-    x86_64-darwin = "sha256-b4ljBeJ9LtakT3ues4WFGu1WoH0EmD1Do+maYWdQGd4=";
     aarch64-darwin = "sha256-iXnkrpdj3p9W1lCPCLDnCXMaGlonzJIu8QQVWF5zDk4=";
   }.${system} or throwSystem;
 in
@@ -48,6 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://garden.io/";
     downloadPage = "https://github.com/garden-io/garden/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-darwin" "aarch64-linux" ];
   };
 })

--- a/binWrapper/inspect.nix
+++ b/binWrapper/inspect.nix
@@ -7,14 +7,12 @@ let
   plat = {
     x86_64-linux = "linux-x86_64";
     aarch64-linux = "linux-aarch64";
-    x86_64-darwin = "macos-x86_64";
     aarch64-darwin = "macos-aarch64";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-linux = "99cf4ea2a2a1048d8e9369a6a5a11e5f84ee3f3c706e0bde072f9b2bd44e96ba";
     aarch64-linux = "2327c1de10ecf40e5199c15fdc4c4b3c173735640294e779c635f4c15771e4f6";
-    x86_64-darwin = "51751be22f6128229c5dea30dc54e8816b81eb90b53d42b318b11b3afee831d2";
     aarch64-darwin = "e7fed5722af6e14dc668279dd7854109f9778484d48b1a42ead5d2c71b8bb90d";
   }.${system} or throwSystem;
 in
@@ -62,6 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://inspect.ataraxy-labs.com";
     downloadPage = "https://github.com/Ataraxy-Labs/inspect/releases";
     license = licenses.fsl11Asl20;
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
 })

--- a/binWrapper/mirrord.nix
+++ b/binWrapper/mirrord.nix
@@ -8,7 +8,6 @@ let
     x86_64-linux = "linux_x86_64";
     aarch64-linux = "linux_aarch64";
 
-    x86_64-darwin = "mac_universal";
     aarch64-darwin = "mac_universal";
   }.${system} or throwSystem;
 
@@ -18,7 +17,6 @@ let
     x86_64-linux = "sha256-Qm1+qI5WMgoDwudvxynv+He1g7RgqCfbsTjKwYxzCLk=";
     aarch64-linux = "sha256-3Jfv1HUV/jOApA0XJQkK1W/W83KyD59A6jr3TcLUJo4=";
 
-    x86_64-darwin = "sha256-+0NXyGjJ7HJmLVYPgIVjbXuFidnPmHmDY6hFf3CABxA=";
     aarch64-darwin = "sha256-+0NXyGjJ7HJmLVYPgIVjbXuFidnPmHmDY6hFf3CABxA=";
   }.${system} or throwSystem;
 in
@@ -57,6 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://mirrord.dev/";
     downloadPage = "https://github.com/metalbear-co/mirrord/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-darwin" "aarch64-linux" ];
   };
 })

--- a/docs/developer/packaging/BinWrapper.md
+++ b/docs/developer/packaging/BinWrapper.md
@@ -53,12 +53,16 @@ Every binWrapper package must include:
 
 ## Platform-Specific SHA256 Handling
 
-BinWrapper packages must support all four platforms:
+BinWrapper packages must support all three supported platforms:
 
 - `x86_64-linux` - AMD64 Linux
 - `aarch64-linux` - ARM64 Linux
-- `x86_64-darwin` - Intel macOS
 - `aarch64-darwin` - Apple Silicon macOS
+
+> Intel macOS (`x86_64-darwin`) was dropped in v3.0.0. The illustrative
+> snippets further down may still show a four-platform map as an example of
+> the per-platform mapping pattern; new packages should target the three
+> platforms above.
 
 ### Platform Mapping
 

--- a/flake.lock
+++ b/flake.lock
@@ -185,16 +185,15 @@
         "treefmt-nix": "treefmt-nix_6"
       },
       "locked": {
-        "lastModified": 1774482969,
-        "narHash": "sha256-oPM7Gq5ggEXhqEL88lSHDuLUlvpYMrWRadDc7b4kkZA=",
+        "lastModified": 1781893012,
+        "narHash": "sha256-+FhqqUCVrHJDDl59wbvPX6ctgiYmcppRa1GuqQNpyXI=",
         "owner": "AtomiCloud",
         "repo": "sulfone.iridium",
-        "rev": "f587c488b3efa77627dc774a2b687efe20106933",
+        "rev": "3a4e637938c5a9c7e5b4d853c438a4805997262c",
         "type": "github"
       },
       "original": {
         "owner": "AtomiCloud",
-        "ref": "f587c48",
         "repo": "sulfone.iridium",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,9 @@
     , nixpkgs-2605
     , nixpkgs-unstable
     } @inputs:
-    (flake-utils.lib.eachDefaultSystem
+    # Intel macOS (x86_64-darwin) was dropped in v3.0.0; the registry now targets
+    # Linux (x86_64, aarch64) and Apple Silicon (aarch64-darwin) only.
+    (flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ]
       (
         system:
         let

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,7 @@
     treefmt-nix.url = "github:numtide/treefmt-nix";
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     fenix.url = "github:nix-community/fenix";
-    # Pinned to f587c48 (release 2.20.0), the last good commit. The tip 7aeed0e
-    # (2.21.0) fails to build: cyanprint/Cargo.toml declares `bollard = "*"`, and
-    # the semantic-release commit regenerated Cargo.lock floating bollard to
-    # 0.21.0, which renamed MountTypeEnum -> MountType, while
-    # cyanprint/src/coord.rs still imports the old name. Unpin once upstream fixes
-    # the bollard import.
-    cyanprintpkgs.url = "github:AtomiCloud/sulfone.iridium/f587c48";
+    cyanprintpkgs.url = "github:AtomiCloud/sulfone.iridium";
     worktrunkpkgs.url = "github:max-sixty/worktrunk";
     atticpkgs.url = "github:zhaofengli/attic";
 

--- a/rust/toml-cli/default.nix
+++ b/rust/toml-cli/default.nix
@@ -32,7 +32,7 @@ with nixpkgs;
     homepage = "https://github.com/gnprice/toml-cli";
     downloadPage = "https://github.com/gnprice/toml-cli/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-darwin" "aarch64-linux" ];
   };
 
 }


### PR DESCRIPTION
## Summary

Deprecates **Intel macOS (`x86_64-darwin`)** from the registry — the second goal on top of the recent cyanprint upgrade. This is a **breaking change**, so it ships as **v3.0.0**.

The flake switches from `flake-utils.lib.eachDefaultSystem` to an explicit `eachSystem` list, dropping `x86_64-darwin`. Supported systems are now:

- `x86_64-linux`
- `aarch64-linux`
- `aarch64-darwin` (Apple Silicon)

## Changes

- **`flake.nix`** — `eachDefaultSystem` → `eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ]` (the authoritative system boundary)
- **binWrappers** (`gardenio`, `cliproxyapi`, `inspect`, `codecov`, `mirrord`, `coderabbit`) — removed the now-dead `x86_64-darwin` entries from `plat`/`sha256` maps and `meta.platforms`
- **`rust/toml-cli`** — removed `x86_64-darwin` from `meta.platforms`

## Verification

- `nix eval` confirms `packages.x86_64-darwin` no longer exists; `aarch64-darwin` retains all 33 packages
- `nix build .#defaultPackage.aarch64-darwin` (builds every package) — **green**
- `nix fmt` clean; pre-commit hooks (treefmt, gitlint, secret scan) pass

## Release impact

`remove(...)` + `BREAKING CHANGE:` footer → major bump: **2.27.0 → 3.0.0**.

⚠️ Intel Mac users must pin a release `<= v2.27.0`.

https://claude.ai/code/session_01Rio8HNDX5jrx2T34Sn2UYa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dropped Intel macOS (x86_64-darwin) platform support across binWrapper CLI packages and Nix packaging/metadata, limiting builds to x86_64-linux, aarch64-linux, and aarch64-darwin.
  * Updated flake system targeting and CI workflow matrices to match the reduced platform set; restructured cache tags and adjusted Nix setup usage/version and `nix shell` resource flags.
  * Updated reusable cache build/shell workflows to remove the macOS x86_64 target.
* **Documentation**
  * Revised the BinWrapper packaging guide to require support for only the three remaining platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->