### PR TITLE
update(cyanprint): upgrade to 2.22.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
         "treefmt-nix": "treefmt-nix_6"
       },
       "locked": {
-        "lastModified": 1781893012,
-        "narHash": "sha256-+FhqqUCVrHJDDl59wbvPX6ctgiYmcppRa1GuqQNpyXI=",
+        "lastModified": 1782240857,
+        "narHash": "sha256-LmxHUQ5jd24Z9VctPUvcZClrBjc2CKzhSSmllGbfc0c=",
         "owner": "AtomiCloud",
         "repo": "sulfone.iridium",
-        "rev": "3a4e637938c5a9c7e5b4d853c438a4805997262c",
+        "rev": "c98b8365d7623be8df4fed15f44a6ab934fa936c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bump `sulfone.iridium` (cyanprint) from **2.21.1** → **2.22.0**.

The `cyanprintpkgs` input URL already tracks the default branch tip, so the only change is `flake.lock` (rev `3a4e637` → `c98b836`).

## Why

2.22.0 is the latest release (tagged today). It adds recording of cyanprint-managed files in cyan state. bollard stays pinned to `0.21`, so the regression that broke 2.21.0 does not recur.

## How tested

- `nix flake update cyanprintpkgs` → locks to v2.22.0 commit `c98b836`
- `nix build .#cyanprint` builds cleanly from source (exit 0)
- `cyanprint --version` → `cyanprint 2.22.0`

https://claude.ai/code/session_01S86ivYuUfiMigYcT9FTj9m