### PR TITLE
update(dn-inspect): configurable .NET SDK, default to .NET 10

### DIFF
--- a/shellWrapper/dn-inspect/default.nix
+++ b/shellWrapper/dn-inspect/default.nix
@@ -1,10 +1,24 @@
 { trivialBuilders, nixpkgs }:
 
-trivialBuilders.writeShellScriptBin {
-  name = "dn-inspect";
-  version = "0.2.0";
-  text = ''
-    export PATH="${nixpkgs.lib.makeBinPath [ nixpkgs.dotnet-sdk_8 nixpkgs.jq nixpkgs.coreutils nixpkgs.findutils ]}:$PATH"
-    ${./dn-inspect.sh} "$@"
-  '';
-}
+# dn-inspect: AtomiCloud wrapper around JetBrains inspectcode (.NET code inspection).
+# NOTE: distinct from the unrelated 'inspect' CLI (Ataraxy-Labs) in binWrapper/inspect.nix.
+
+let
+  # Version of the dn-inspect tool (keep in sync with dn-inspect.sh).
+  version = "0.3.0";
+
+  # Create a function that takes dotnetPackage as an argument so the .NET SDK is
+  # configurable (mirrors shellWrapper/dotnetlint/default.nix). Defaults to .NET 10.
+  makeDnInspect = { dotnetPackage ? nixpkgs.dotnetPackage or nixpkgs.dotnet-sdk_10 }:
+    trivialBuilders.writeShellScriptBin {
+      name = "dn-inspect";
+      inherit version;
+      text = ''
+        export PATH="${nixpkgs.lib.makeBinPath [ dotnetPackage nixpkgs.jq nixpkgs.coreutils nixpkgs.findutils ]}:$PATH"
+        export DN_INSPECT_DOTNET="${dotnetPackage}"
+        ${./dn-inspect.sh} "$@"
+      '';
+    };
+in
+# Make the function overridable, which adds the override attribute.
+nixpkgs.lib.makeOverridable makeDnInspect { }

--- a/shellWrapper/dn-inspect/dn-inspect.sh
+++ b/shellWrapper/dn-inspect/dn-inspect.sh
@@ -2,7 +2,11 @@
 set -eou pipefail
 
 # Handle --version
-[ "${1:-}" = "--version" ] && echo "ℹ️ dn-inspect 0.2.0" && exit 0
+if [ "${1:-}" = "--version" ]; then
+  echo "ℹ️ dn-inspect 0.3.0"
+  echo "using dotnet: $("${DN_INSPECT_DOTNET:+$DN_INSPECT_DOTNET/bin/}dotnet" --version)"
+  exit 0
+fi
 
 # Find .sln in current directory
 solution=$(find . -maxdepth 1 -name '*.sln' -print -quit 2>/dev/null)


### PR DESCRIPTION
## What

Makes `dn-inspect`'s .NET SDK a **configurable input** and upgrades the **default to .NET 10**, mirroring the existing `dotnetlint` pattern.

Previously the wrapper hardcoded `dotnet-sdk_8` onto PATH ahead of whatever the repo provides, so a repo pinning a newer SDK (e.g. .NET 10 via `global.json`) hit SDK-resolution failures and had to call the JetBrains tool directly to sidestep the wrapper.

## Changes

- `shellWrapper/dn-inspect/default.nix`
  - Convert the derivation to a `nixpkgs.lib.makeOverridable` function with a `dotnetPackage` input (mirrors `shellWrapper/dotnetlint/default.nix`).
  - Default the input to **`dotnet-sdk_10`** (stable 10.0.300 from the registry's existing 26.05 pin), replacing `dotnet-sdk_8`.
  - Keep `jq` / `coreutils` / `findutils` on PATH so real inspection runs still work.
  - Pass the resolved SDK to the script via `DN_INSPECT_DOTNET`.
  - Bump version `0.2.0` → `0.3.0`; add a comment clarifying `dn-inspect` (JetBrains inspectcode) is distinct from the unrelated `inspect` CLI in `binWrapper/inspect.nix`.
- `shellWrapper/dn-inspect/dn-inspect.sh`
  - `--version` now also reports the resolved .NET SDK version (like `dotnetlint`).

The registry's existing import at `shellWrapper/default.nix:8` is **unchanged** — `makeOverridable f {}` still returns a working package.

## Usage

```nix
# default — now .NET 10
atomi.dn-inspect

# override to any SDK
atomi.dn-inspect.override { dotnetPackage = nix-2605.dotnet-sdk_8; }
```

## Verification

- `nix build .#dn-inspect` → succeeds.
- Default `dn-inspect --version` → `ℹ️ dn-inspect 0.3.0` + `using dotnet: 10.0.300`.
- `.override { dotnetPackage = …dotnet-sdk_8; }` build → `using dotnet: 8.0.421` (confirms the override resolves a different SDK).
- `shellcheck` + `treefmt` clean on the changed files.

## Notes

- This is a deliberate **default-behavior change**: consumers that don't override move from .NET 8 → .NET 10. The override path (including back to 8) remains available.
- Updating the downstream `diene.dotnet-base` to adopt the override is out of scope (tracked in its own PR).

https://claude.ai/code/session_01NUQjFRpcAZUfMJuwRxneTx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `dn-inspect` now supports choosing which .NET package it uses at runtime, with a newer default option.
  * The tool’s wrapper can now be customized by callers instead of using a fixed build setup.

* **Bug Fixes**
  * Improved version reporting so `dn-inspect --version` now shows the updated release number and the .NET version being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->