### PR TITLE
update(dn-inspect): support .slnx and project-only mode

### DIFF
--- a/shellWrapper/dn-inspect/default.nix
+++ b/shellWrapper/dn-inspect/default.nix
@@ -5,7 +5,7 @@
 
 let
   # Version of the dn-inspect tool (keep in sync with dn-inspect.sh).
-  version = "0.3.0";
+  version = "0.4.0";
 
   # Create a function that takes dotnetPackage as an argument so the .NET SDK is
   # configurable (mirrors shellWrapper/dotnetlint/default.nix). Defaults to .NET 10.
@@ -14,7 +14,9 @@ let
       name = "dn-inspect";
       inherit version;
       text = ''
-        export PATH="${nixpkgs.lib.makeBinPath [ dotnetPackage nixpkgs.jq nixpkgs.coreutils nixpkgs.findutils ]}:$PATH"
+        # gawk + gnused are used by dn-inspect.sh (the inspectcode stderr noise
+        # filter and quote_arg's single-quote escaping), so bundle them too.
+        export PATH="${nixpkgs.lib.makeBinPath [ dotnetPackage nixpkgs.jq nixpkgs.coreutils nixpkgs.findutils nixpkgs.gawk nixpkgs.gnused ]}:$PATH"
         export DN_INSPECT_DOTNET="${dotnetPackage}"
         ${./dn-inspect.sh} "$@"
       '';

--- a/shellWrapper/dn-inspect/dn-inspect.sh
+++ b/shellWrapper/dn-inspect/dn-inspect.sh
@@ -3,19 +3,42 @@ set -eou pipefail
 
 # Handle --version
 if [ "${1:-}" = "--version" ]; then
-  echo "ℹ️ dn-inspect 0.3.0"
+  echo "ℹ️ dn-inspect 0.4.0"
   echo "using dotnet: $("${DN_INSPECT_DOTNET:+$DN_INSPECT_DOTNET/bin/}dotnet" --version)"
   exit 0
 fi
 
-# Find .sln in current directory
-solution=$(find . -maxdepth 1 -name '*.sln' -print -quit 2>/dev/null)
+# The bundled JetBrains command-line tool (`dotnet jb`) targets an older .NET
+# runtime than the SDK we now bundle for `.slnx` support, so allow the host to
+# roll forward to the bundled major. Respect an explicit caller override.
+export DOTNET_ROLL_FORWARD="${DOTNET_ROLL_FORWARD:-Major}"
+
+# Auto-discover a solution in the current directory. Both `.sln` (legacy) and
+# `.slnx` (modern) are supported. Both-present rule: prefer `.slnx`, the modern
+# canonical format, so behaviour is deterministic when both exist.
+solution=$(find . -maxdepth 1 -name '*.slnx' -print -quit 2>/dev/null)
+[ -z "$solution" ] && solution=$(find . -maxdepth 1 -name '*.sln' -print -quit 2>/dev/null)
 solution="${solution#./}"
 filter=""
 use_projects=false
-projects=""
 no_build=false
-include_patterns=""
+
+# Accumulate argument lists that may contain whitespace (project paths, include
+# globs) as eval-safe, single-quoted tokens rather than a space-delimited string.
+# A space-delimited string expanded unquoted word-splits a path like
+# `Space Name.slnx` into two arguments, so `dotnet jb inspectcode` aborts with
+# "Specify only one solution file". These are rebuilt into positional parameters
+# with `eval set --` at the point of use, preserving each argument intact.
+project_args=""
+include_args=""
+
+# Wrap $1 in single quotes (escaping any embedded single quote) so the result is
+# safe to reconstruct with `eval`. POSIX sh has a single array — the positional
+# parameters — so this is the portable way to carry a list of whitespace-bearing
+# values until they are turned back into "$@".
+quote_arg() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -30,25 +53,34 @@ while [ "$#" -gt 0 ]; do
     shift
     ;;
   --include=*)
-    include_patterns="$include_patterns --include=${1#--include=}"
+    include_args="$include_args $(quote_arg "--include=${1#--include=}")"
     shift
     ;;
   --include)
     shift
     [ -z "${1:-}" ] && echo "❌ Error: --include requires a pattern" >&2 && exit 1
-    include_patterns="$include_patterns --include=$1"
+    include_args="$include_args $(quote_arg "--include=$1")"
     shift
     ;;
   --projects)
     shift
     [ "$#" -eq 0 ] && echo "❌ Error: --projects requires at least one project" >&2 && exit 1
     use_projects=true
+    # Track whether at least one real project token was collected: the loop below
+    # stops at the next option, so `--projects --no-build` would otherwise set
+    # use_projects=true with an empty list and inspect an empty temp solution.
+    has_project=false
     while [ "$#" -gt 0 ] && [ "${1#--}" = "$1" ]; do
-      projects="$projects $1"
+      has_project=true
+      project_args="$project_args $(quote_arg "$1")"
       shift
     done
+    if [ "$has_project" != true ]; then
+      echo "❌ Error: --projects requires at least one project" >&2
+      exit 1
+    fi
     ;;
-  *.sln)
+  *.sln | *.slnx)
     solution="$1"
     shift
     ;;
@@ -59,8 +91,17 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-[ -z "$solution" ] && echo "❌ Error: No .sln file found in current directory" >&2 && exit 1
-[ ! -f "$solution" ] && echo "❌ Error: File not found: $solution" >&2 && exit 1
+# Project-only mode fabricates its own temp solution, so it must not require a
+# discovered one — nor validate one. Both the empty-solution guard and the
+# file-existence guard are skipped under --projects: auto-discovery may surface a
+# broken/missing solution (e.g. a dangling `*.slnx` symlink) that project mode
+# would otherwise reject before reaching temp-solution creation. The discovered
+# solution is overwritten by the temp solution in project mode anyway. Keep both
+# guards for every other invocation.
+if [ "$use_projects" != true ]; then
+  [ -z "$solution" ] && echo "❌ Error: No .sln/.slnx file found in current directory" >&2 && exit 1
+  [ -n "$solution" ] && [ ! -f "$solution" ] && echo "❌ Error: File not found: $solution" >&2 && exit 1
+fi
 
 base_tmp_dir="${TMPDIR:-/tmp}"
 if [ -n "${DN_INSPECT_REPORT_FILE:-}" ]; then
@@ -83,15 +124,22 @@ if [ "$use_projects" = true ]; then
     cleanup_sln_dir=true
   fi
   echo "🧩 Creating temp solution: $sln_file"
-  dotnet new sln --output "$(dirname "$sln_file")" --name "$(basename "$sln_file" .sln)" >/dev/null
-  for project in $projects; do
+  # Force the legacy `.sln` format so the created file's extension matches the
+  # `.sln` name used below — on a `.slnx`-defaulting SDK (.NET 10) `dotnet new
+  # sln` would otherwise emit a `.slnx` and the subsequent `add`/inspect on
+  # `$sln_file` (a `.sln`) would fail.
+  dotnet new sln --format sln --output "$(dirname "$sln_file")" --name "$(basename "$sln_file" .sln)" >/dev/null
+  # Rebuild the project list into positional parameters so each path (which may
+  # contain whitespace) is added as a single argument.
+  eval "set -- $project_args"
+  for project in "$@"; do
     echo "➕ Adding project: $project"
     dotnet sln "$sln_file" add "$project" >/dev/null
   done
   echo "✅ Temp solution ready"
 fi
 
-trap '[ "$cleanup_report" = false ] || rm -f "$report_file"; [ "$cleanup_sln_dir" = false ] || [ -z "${sln_dir:-}" ] || rm -rf "$sln_dir"' EXIT
+trap '[ "$cleanup_report" = false ] || rm -f "$report_file"; [ "$cleanup_sln_dir" = false ] || [ -z "${sln_dir:-}" ] || rm -rf "$sln_dir"; rm -f "${inspect_err:-}"' EXIT
 
 if [ -n "$filter" ]; then
   echo "🔍 Running inspectcode with filter: $filter"
@@ -99,12 +147,77 @@ else
   echo "🔍 Running inspectcode"
 fi
 
-inspectcode_args="$sln_file --format=Sarif --output=$report_file"
-[ "$no_build" = true ] && inspectcode_args="$inspectcode_args --no-build"
-[ -n "$include_patterns" ] && inspectcode_args="$inspectcode_args$include_patterns"
+# Build the inspectcode invocation in positional parameters so the solution path
+# and every include glob are passed as single, intact arguments even when they
+# contain whitespace (see quote_arg above).
+set -- "$sln_file" "--format=Sarif" "--output=$report_file"
+[ "$no_build" = true ] && set -- "$@" "--no-build"
+[ -n "$include_args" ] && eval "set -- \"\$@\" $include_args"
 
-# shellcheck disable=SC2086
-dotnet jb inspectcode $inspectcode_args
+# ReSharper's analyzer host runs on the rolled-forward .NET 10 runtime, where the
+# SDK's own bundled Roslyn analyzers / source generators fail to instantiate
+# (`System.Composition.AttributedModel` not found) and flood *stderr* with
+# hundreds of non-fatal exception dumps per run. stdout and the SARIF report are
+# unaffected, and a genuine build/inspection failure is signalled by `dotnet jb`'s
+# non-zero exit code — not by this stderr text. So: capture stderr; on success
+# drop only that known-benign analyzer-load noise; on failure pass stderr through
+# untouched and propagate the exit code, so nothing is ever hidden when something
+# actually breaks.
+#
+# Suppression is BLOCK-SCOPED, not a global line-level blacklist: a block is
+# dropped only when it carries BOTH benign anchors — the `Roslyn error
+# ProviderInstantiation` headline AND the missing `System.Composition.AttributedModel`
+# assembly. The noise arrives in two shapes, both handled by the awk filter below:
+#   1. a single condensed `Roslyn error ProviderInstantiation …` line, and
+#   2. a multi-line `--- EXCEPTION … [LoggerException]` dump terminated by a blank line.
+# Any block missing either anchor — a consumer's OWN analyzer failing to load
+# (different assembly name), a real `CSxxxx`/`MSBxxxx` diagnostic, an unrelated
+# exception — is passed through verbatim. This is deliberately conservative:
+# under-suppression (showing harmless extra lines) is preferred over hiding a real
+# diagnostic. The filter is tied to the ReSharper 2026.1.3 + SDK 10 dump format and
+# should be revisited on the next toolchain bump.
+inspect_err="$(mktemp "${base_tmp_dir%/}/dn-inspect-stderr.XXXXXX")"
+# This is an awk program; `$0`/fields are awk syntax, not shell expansions.
+# shellcheck disable=SC2016
+inspect_filter='
+function flush(   i) {
+  # Print the buffered LoggerException block unless it is the known-benign one
+  # (both anchors present); either way reset the block state.
+  if (!(blk_roslyn && blk_assembly)) { for (i = 1; i <= n; i++) print buf[i]; dropped = 0 }
+  else { dropped = 1 }
+  n = 0; blk_roslyn = 0; blk_assembly = 0; in_blk = 0
+}
+{
+  if (in_blk) {
+    buf[++n] = $0
+    if (index($0, "Roslyn error ProviderInstantiation")) blk_roslyn = 1
+    if (index($0, "System.Composition.AttributedModel")) blk_assembly = 1
+    if ($0 == "") flush()
+    next
+  }
+  if ($0 ~ /^--- EXCEPTION .*\[LoggerException\]/) {
+    in_blk = 1; n = 0; blk_roslyn = 0; blk_assembly = 0; buf[++n] = $0; next
+  }
+  if ($0 ~ /^Roslyn error ProviderInstantiation/ && index($0, "System.Composition.AttributedModel")) {
+    dropped = 1; next
+  }
+  if ($0 == "" && dropped) next       # collapse blanks left behind by dropped noise
+  dropped = 0
+  print
+}
+END { if (in_blk) flush() }
+'
+set +e
+dotnet jb inspectcode "$@" 2>"$inspect_err"
+inspect_ec=$?
+set -e
+if [ "$inspect_ec" -eq 0 ]; then
+  awk "$inspect_filter" "$inspect_err" >&2
+else
+  cat "$inspect_err" >&2
+fi
+rm -f "$inspect_err"
+[ "$inspect_ec" -eq 0 ] || exit "$inspect_ec"
 
 [ ! -s "$report_file" ] && echo "✅ No SARIF output produced" && echo "📊 Total: 0 issue(s)" && exit 0
 


### PR DESCRIPTION
## What

Makes `dn-inspect` a first-class citizen of the .NET 10 `.slnx` workflow, building on the already-merged configurable-SDK work (#48, `dotnet-sdk_10`).

- **`.slnx` as a solution input** — accepted explicitly and auto-discovered; when both a `.sln` and `.slnx` are present, `.slnx` (the modern canonical format) is preferred. Explicit input still wins over discovery.
- **Standalone `--projects` mode** — no longer trips the "no solution found" guard, and the temp solution is created with `dotnet new sln --format sln` so it works on a `.slnx`-defaulting SDK (.NET 10).
- **Toolchain** — sets `DOTNET_ROLL_FORWARD=Major` so `dotnet jb inspectcode` runs on SDK 10; bundles `gawk` + `gnused` (used by the script).
- **Robustness** — whitespace-bearing project/include arguments are handled safely; benign Roslyn analyzer-load stderr noise is filtered (conservatively — passed through verbatim on any non-zero exit).
- **Backward-compat** — existing `.sln` usage is unchanged.
- Version bump `0.3.0` → `0.4.0`.

## Verification

- `nix build .#dn-inspect` → builds `dn-inspect-0.4.0`.
- `dn-inspect --version` → `0.4.0`, `using dotnet: 10.0.300`.
- `shellcheck` clean; `treefmt` idempotent.
- Functional: explicit `.slnx`, `.slnx` auto-discovery, both-present prefers `.slnx`, standalone `--projects`, and a `.sln` regression check all pass against a .NET 10 sample (kloop evidence).

Closes dn-inspect `.slnx` / project-only support (ClickUp 86ey3t9dt).

By Claude Code kautopilot 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved solution discovery to support both `.sln` and `.slnx`, deterministically preferring `.slnx` when both are present.
  * Enhanced command-line argument handling for safer processing of values with spaces.
* **Bug Fixes**
  * Improved project-only inspection reliability by generating a legacy `.sln` when no solution is selected.
  * Suppressed a known benign analyzer-load noise pattern in output while preserving real error details.
* **Chores**
  * Updated embedded tool to version `0.4.0` (including reporting `--version`) and adjusted runtime environment defaults for .NET roll-forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->