### PR TITLE
new(dashboard-linter): package grafana/dashboard-linter v0.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,7 @@ jobs:
           .#clickup_cli
           .#inspect
           .#pagerduty_cli
+          .#dashboard-linter
           -c bash -c '
           sg --version &&
           upstash --version &&
@@ -125,6 +126,7 @@ jobs:
           inspect --help &&
           attic --version &&
           cli-proxy-api --help &&
+          dashboard-linter --help &&
           echo "🎉 Done"'
 
   release:

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,7 @@ let
   golang = {
     nix-share = import ./golang/nix-share/default.nix { inherit nixpkgs; };
     ccc = import ./golang/ccc/default.nix { inherit nixpkgs; };
+    dashboard-linter = import ./golang/dashboard-linter/default.nix { inherit nixpkgs; };
   };
 
   # dotnet

--- a/golang/dashboard-linter/default.nix
+++ b/golang/dashboard-linter/default.nix
@@ -1,0 +1,22 @@
+{ nixpkgs }:
+with nixpkgs;
+buildGoModule rec {
+  pname = "dashboard-linter";
+  version = "v0.2.0";
+
+  meta = {
+    owner = "grafana";
+    repo = "dashboard-linter";
+  };
+
+  src = fetchurl {
+    url = "https://github.com/${meta.owner}/${meta.repo}/archive/refs/tags/${version}.tar.gz";
+    sha256 = "sha256-N0SA82Ve0Ck6/JUVRldJkgRcXi0w1BupnpLpk/AbHVU=";
+  };
+
+  vendorHash = "sha256-rWJqlsmGoCVhEbt0ersZP5RFaKcG0xq5jHy4Tm7SoU0=";
+
+  doCheck = false;
+
+  ldflags = [ "-w" "-s" "-a" ];
+}


### PR DESCRIPTION
## Summary
- Packages `grafana/dashboard-linter` v0.2.0 as a new Go CLI package in `nix-registry`, following the existing `nix-share`/`ccc` `buildGoModule` pattern.
- Wires the package into the root `default.nix` `golang` attrset, exposing it as a flake package output with no `flake.nix` changes needed.
- Extends CI's "Nix Build" step to build and smoke-check `dashboard-linter --help` (no `--version` flag upstream) alongside the other packaged Go CLIs.

## Why
`dashboard-linter` isn't in nixpkgs, and AtomiCloud policy requires tooling to come from nix dev shells. This makes the tool available to any service repo's flake so the observability standard's `dashboard-linter lint --strict` self-verification step no longer needs to skip when the tool is absent. Adopting it in a consumer repo is separate follow-up work.

## Test plan
- [x] `nix build .#dashboard-linter` — builds successfully with real (non-placeholder) source + vendor hashes
- [x] `nix shell .#dashboard-linter -c dashboard-linter --help` — exits 0, prints genuine upstream usage output
- [x] Confirmed `default.nix`'s `golang` attrset follows the same shape as `nix-share`/`ccc`
- [x] `treefmt` — no formatting diffs on changed files

By Claude Code kautopilot 🤖

https://claude.ai/code/session_011rrgxM6mNiYR6thB2D9WDz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dashboard-linter` to the build and CI toolchain, making it available in automated validation.
  * CI now runs an additional `dashboard-linter` help check as part of the build verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->