### PR TITLE
new(nsc): add Namespace Cloud CLI (nsc)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,7 @@ jobs:
           .#inspect
           .#pagerduty_cli
           .#dashboard-linter
+          .#nsc
           -c bash -c '
           sg --version &&
           upstash --version &&
@@ -127,6 +128,7 @@ jobs:
           attic --version &&
           cli-proxy-api --help &&
           dashboard-linter --help &&
+          nsc version &&
           echo "🎉 Done"'
 
   release:

--- a/binWrapper/nsc.nix
+++ b/binWrapper/nsc.nix
@@ -1,0 +1,59 @@
+{ nixpkgs }:
+with nixpkgs;
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  plat = {
+    x86_64-linux = "linux_amd64";
+    aarch64-linux = "linux_arm64";
+
+    aarch64-darwin = "darwin_arm64";
+  }.${system} or throwSystem;
+
+  sha256 = {
+    x86_64-linux = "sha256-suxxRscqokyVkwE1JZ3Wuool/cTa4vySNGKGrHG+oPw=";
+    aarch64-linux = "sha256-lNgnALrYUBkSgvKmOVtW6jOmfWCTc3ITD64VwzdHzWo=";
+
+    aarch64-darwin = "sha256-floxGKsUhXS3ZYBdHLoWwzoFlt9Qpl9oeM9j2PF//kA=";
+  }.${system} or throwSystem;
+in
+let version = "0.0.532"; in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nsc";
+  inherit version;
+
+  # The release archive unpacks flat (no top-level directory), so stdenv can't
+  # infer a sourceRoot to cd into.
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    # Main CLI plus the docker/bazel credential helpers shipped alongside it.
+    for bin in nsc docker-credential-nsc bazel-credential-nsc; do
+      cp "$bin" "$out/bin/$bin"
+      chmod +x "$out/bin/$bin"
+    done
+  '';
+
+  src = builtins.fetchurl {
+    url = "https://github.com/namespacelabs/foundation/releases/download/v${version}/nsc_${version}_${plat}.tar.gz";
+    inherit sha256;
+  };
+
+  meta = with lib; {
+    description = "Namespace Cloud CLI";
+    longDescription = ''
+      nsc is the command-line interface for Namespace Cloud, providing access to
+      Namespace's developer-optimized compute platform (remote builds, ephemeral
+      environments, CI runners and container registries). Published by
+      namespacelabs/foundation as versioned, per-platform prebuilt binaries.
+    '';
+    mainProgram = "nsc";
+    homepage = "https://namespace.so/";
+    downloadPage = "https://github.com/namespacelabs/foundation/releases";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+  };
+})

--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,7 @@ let
     coderabbit = import ./binWrapper/coderabbit.nix { inherit nixpkgs; };
     cliproxyapi = import ./binWrapper/cliproxyapi.nix { inherit nixpkgs; };
     inspect = import ./binWrapper/inspect.nix { inherit nixpkgs; };
+    nsc = import ./binWrapper/nsc.nix { inherit nixpkgs; };
   };
 
   rust = import ./rust/default.nix { inherit nixpkgs fenix; };


### PR DESCRIPTION
## What

Adds the **Namespace Cloud CLI (`nsc`)** to the registry as a `binWrapper` derivation (`binWrapper/nsc.nix`), wired into `default.nix` under the `bin` set.

Source: [`namespacelabs/foundation`](https://github.com/namespacelabs/foundation/releases) prebuilt release tarballs, pinned to **v0.0.532**.

## Details

- Fetches per-platform prebuilt binaries for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin` (matching the platform set used by the other binWrappers e.g. `cyanprint`, `gardenio`).
- The release archive unpacks flat, so `sourceRoot = "."` (same as `cyanprint`).
- Installs `nsc` plus the `docker-credential-nsc` and `bazel-credential-nsc` credential helpers shipped in the same tarball. `mainProgram = "nsc"`.
- License: Apache-2.0 (`licenses.asl20`), matching upstream.

## How to test

```bash
nix build .#nsc
./result/bin/nsc version   # -> version v0.0.532
```

Verified locally on `aarch64-darwin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `nsc` command-line tool in the package set.
  * The tool now installs its main executable plus related credential helpers for use from the terminal.
  * `nsc` is now exposed through the default package output, making it available alongside the existing binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->