### PR TITLE
new(codemagic-cli-tools): add codemagic-cli-tools Python package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
           .#toml-cli
           .#nix-share
           .#aws-export-credentials
+          .#codemagic-cli-tools
           .#cyanprint
           .#worktrunk
           .#atomiutils
@@ -129,6 +130,7 @@ jobs:
           cli-proxy-api --help &&
           dashboard-linter --help &&
           nsc version &&
+          app-store-connect --version &&
           echo "🎉 Done"'
 
   release:

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ let
   # Python
   python = {
     aws-export-credentials = import ./python/aws-export-credentials/default.nix { inherit nixpkgs; };
+    codemagic-cli-tools = import ./python/codemagic-cli-tools/default.nix { inherit nixpkgs; };
   };
 
   # Go

--- a/python/codemagic-cli-tools/default.nix
+++ b/python/codemagic-cli-tools/default.nix
@@ -1,0 +1,37 @@
+{ nixpkgs, pyPkgs ? nixpkgs.pkgs.python3Packages }:
+with pyPkgs;
+buildPythonPackage rec {
+  pname = "codemagic-cli-tools";
+  version = "0.68.0";
+  format = "wheel";
+
+  # Only a wheel is published to PyPI for this version (no sdist), so fetch the
+  # py3 wheel. fetchPypi builds the wheel filename from the underscore-normalised
+  # name: codemagic_cli_tools-${version}-py3-none-any.whl
+  src = fetchPypi {
+    pname = "codemagic_cli_tools";
+    inherit version format;
+    dist = "py3";
+    python = "py3";
+    sha256 = "sha256-+0xpWuH+FqWjUBbk0lN+sFWSy9L5+yJU0DzQflrdGbM=";
+  };
+
+  # Relax the pinned lower bounds so we can use the nixpkgs-provided versions.
+  pythonRelaxDeps = true;
+
+  propagatedBuildInputs = [
+    cryptography
+    google-api-python-client
+    httplib2
+    oauth2client
+    packaging
+    psutil
+    pyjwt
+    python-dateutil
+    requests
+  ];
+
+  checkPhase = ''
+    echo "no test!"
+  '';
+}


### PR DESCRIPTION
## What

Packages **codemagic-cli-tools 0.68.0** in the nix-registry.

Part of the Nix CI overhaul ([CU-86ey7122q](https://app.clickup.com/t/86ey7122q)) — lets iOS CD jobs consume the tool from the Nix store instead of a per-run `pipx install`.

## How

- `python/codemagic-cli-tools/default.nix` — new `buildPythonPackage`. PyPI publishes only a py3 wheel for this version (no sdist), so the derivation uses `format = "wheel"` and pulls all nine runtime deps (cryptography, google-api-python-client, httplib2, oauth2client, packaging, psutil, pyjwt, python-dateutil, requests) from nixpkgs `python3Packages`.
- `default.nix` — registered under the `python` set.
- `.github/workflows/ci.yaml` — added `.#codemagic-cli-tools` to the Nix Build list and `app-store-connect --version` to the smoke test.

## Testing

Built locally and verified all 10 CLI entry points install and run (`app-store-connect`, `xcode-project`, `keychain`, `codemagic-cli-tools`, `google-play`, etc.):

```
$ nix shell .#codemagic-cli-tools -c app-store-connect --version
app-store-connect 0.68.0
```

https://claude.ai/code/session_01CXjfigAbJnHhE68xCJCxBD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to include an additional CLI tool used during CI validation.
  * Expanded version checks in the build step to verify one more command is available, improving build confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->